### PR TITLE
Actually call __exit__() when required

### DIFF
--- a/uefi_r2/uefi_analyzer.py
+++ b/uefi_r2/uefi_analyzer.py
@@ -372,5 +372,5 @@ class r2_uefi_analyzer():
     def close(self):
         self.r2.quit()
 
-    def __exit__(self):
+    def __exit__(self, exception_type, exception_value, traceback):
         self.r2.quit()


### PR DESCRIPTION
The __exit__ method defined is not correct. The method is supposed to take four
arguments: self, exception type, exception value, and traceback. Because the
method signature does not match what Python expects, __exit__ is never called.