### PR TITLE
fix scan-firmware command when used from fwhunt_scan_docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-LABEL org.opencontainers.image.source https://github.com/binarly-io/fwhunt-scan
+LABEL org.opencontainers.image.source=https://github.com/binarly-io/fwhunt-scan
 
 ARG rz_version=v0.6.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11
 
 LABEL org.opencontainers.image.source=https://github.com/binarly-io/fwhunt-scan
 

--- a/fwhunt_scan/uefi_analyzer.py
+++ b/fwhunt_scan/uefi_analyzer.py
@@ -18,15 +18,23 @@ import rzpipe
 
 import fwhunt_scan.uefi_smm as uefi_smm
 from fwhunt_scan.uefi_protocols import GUID_FROM_BYTES
-from fwhunt_scan.uefi_tables import (BS_PROTOCOLS_INFO_64_BIT,
-                                     EFI_BOOT_SERVICES_64_BIT,
-                                     EFI_PEI_SERVICES_32_BIT,
-                                     EFI_RUNTIME_SERVICES_64_BIT,
-                                     OFFSET_TO_SERVICE)
+from fwhunt_scan.uefi_tables import (
+    BS_PROTOCOLS_INFO_64_BIT,
+    EFI_BOOT_SERVICES_64_BIT,
+    EFI_PEI_SERVICES_32_BIT,
+    EFI_RUNTIME_SERVICES_64_BIT,
+    OFFSET_TO_SERVICE,
+)
 from fwhunt_scan.uefi_te import TerseExecutableError, TerseExecutableParser
-from fwhunt_scan.uefi_types import (ChildSwSmiHandler, NvramVariable,
-                                    SmiHandler, UefiGuid, UefiProtocol,
-                                    UefiProtocolGuid, UefiService)
+from fwhunt_scan.uefi_types import (
+    ChildSwSmiHandler,
+    NvramVariable,
+    SmiHandler,
+    UefiGuid,
+    UefiProtocol,
+    UefiProtocolGuid,
+    UefiService,
+)
 from fwhunt_scan.uefi_utils import get_current_insn_index, get_int
 
 if sys.version_info.major == 3 and sys.version_info.minor >= 8:

--- a/fwhunt_scan/uefi_scanner.py
+++ b/fwhunt_scan/uefi_scanner.py
@@ -12,8 +12,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
-from fwhunt_scan.uefi_analyzer import (NvramVariable, UefiAnalyzer, UefiGuid,
-                                       UefiProtocol, UefiService)
+from fwhunt_scan.uefi_analyzer import (
+    NvramVariable,
+    UefiAnalyzer,
+    UefiGuid,
+    UefiProtocol,
+    UefiService,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/fwhunt_scan/uefi_smm.py
+++ b/fwhunt_scan/uefi_smm.py
@@ -8,8 +8,12 @@ import rzpipe
 
 from fwhunt_scan.uefi_protocols import UefiGuid
 from fwhunt_scan.uefi_types import ChildSwSmiHandler, SmiHandler, SmiKind
-from fwhunt_scan.uefi_utils import (get_current_insn_index, get_int,
-                                    get_xrefs_to_data, get_xrefs_to_guids)
+from fwhunt_scan.uefi_utils import (
+    get_current_insn_index,
+    get_int,
+    get_xrefs_to_data,
+    get_xrefs_to_guids,
+)
 
 SMI_KINDS = {
     SmiKind.SW_SMI: [

--- a/fwhunt_scan_analyzer.py
+++ b/fwhunt_scan_analyzer.py
@@ -20,6 +20,7 @@ from fwhunt_scan import UefiAnalyzer, UefiExtractor, UefiRule, UefiScanner
 logging.basicConfig(
     format="%(name)s %(asctime)s %(levelname)s: %(message)s",
     datefmt="%m/%d/%Y %I:%M:%S %p",
+    level=os.environ.get("PYTHON_LOG", "INFO"),
 )
 logger = logging.getLogger("fwhunt_scan")
 

--- a/fwhunt_scan_analyzer.py
+++ b/fwhunt_scan_analyzer.py
@@ -20,7 +20,6 @@ from fwhunt_scan import UefiAnalyzer, UefiExtractor, UefiRule, UefiScanner
 logging.basicConfig(
     format="%(name)s %(asctime)s %(levelname)s: %(message)s",
     datefmt="%m/%d/%Y %I:%M:%S %p",
-    level=os.environ.get("PYTHON_LOG", "INFO"),
 )
 logger = logging.getLogger("fwhunt_scan")
 

--- a/fwhunt_scan_docker.py
+++ b/fwhunt_scan_docker.py
@@ -164,9 +164,8 @@ def scan_firmware(
         rules_cmd += ["-r", f"/tmp/{name}"]
 
     if rules_dir:
-        _, name = os.path.split(rules_dir)
-        cmd += ["-v", f"{os.path.realpath(rules_dir)}:/tmp/{name}:ro"]
-        rules_cmd += ["--rules_dir", f"/tmp/{name}"]
+        cmd += ["-v", f"{os.path.realpath(rules_dir)}:/tmp/rules:ro"]
+        rules_cmd += ["-d", f"/tmp/rules"]
 
     cmd += rules_cmd
     cmdstr = " ".join(cmd)

--- a/fwhunt_scan_docker.py
+++ b/fwhunt_scan_docker.py
@@ -11,6 +11,7 @@ import click
 logging.basicConfig(
     format="%(name)s %(asctime)s %(levelname)s: %(message)s",
     datefmt="%m/%d/%Y %I:%M:%S %p",
+    level=os.environ.get("PYTHON_LOG", "INFO"),
 )
 logger = logging.getLogger("fwhunt_scan")
 
@@ -99,7 +100,7 @@ def scan(path: str, rule: List[str]) -> bool:
     cmd += rules_cmd
     cmdstr = " ".join(cmd)
 
-    logger.debug(f"Commamd: {cmdstr}")
+    logger.debug(f"Command: {cmdstr}")
 
     os.system(cmdstr)
 
@@ -170,7 +171,7 @@ def scan_firmware(
     cmd += rules_cmd
     cmdstr = " ".join(cmd)
 
-    logger.debug(f"Commamd: {cmdstr}")
+    logger.debug(f"Command: {cmdstr}")
 
     os.system(cmdstr)
 

--- a/fwhunt_scan_docker.py
+++ b/fwhunt_scan_docker.py
@@ -30,7 +30,7 @@ def build():
 
 
 @click.command()
-@click.argument("module_path")
+@click.argument("path")
 def analyze(path: str) -> bool:
     """Analyze single EFI file."""
 
@@ -178,6 +178,7 @@ def scan_firmware(
 
 
 cli.add_command(build)
+cli.add_command(analyze)
 cli.add_command(analyze, "analyze-module")
 cli.add_command(analyze, "analyze-bootloader")
 cli.add_command(scan)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="fwhunt_scan",
-    version="2.3.7",
+    version="2.3.8",
     author="FwHunt team",
     author_email="fwhunt@binarly.io",
     packages=["fwhunt_scan"],


### PR DESCRIPTION
This PR contains fixes for the `fwhunt_scan_docker.py` script and other minor updates.
